### PR TITLE
allow dev and peer dependency list

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/test"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -338,7 +338,12 @@ function populateDependencyTree(deps, rootModule, rootPackageJson, mod) {
     } else {
       var newDeps = {};
       curDeps[item.packageJson.name] = {
-        requestedVersion: curParentJson.dependencies[item.packageJson.name],
+         requestedVersion:
+          (curParentJson.dependencies &&
+            curParentJson.dependencies[item.packageJson.name]) ||
+          (curParentJson.peerDependencies &&
+            curParentJson.peerDependencies[item.packageJson.name]) ||
+          curParentJson.devDependencies[item.packageJson.name],
         installedVersion: item.packageJson.version,
         dependencies: newDeps,
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backtrace-node",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Backtrace error reporting tool",
   "main": "lib/index.js",
   "author": "Backtrace <team@backtrace.io>",


### PR DESCRIPTION
Discovered dependencies is not ALWAYS present in package.json, EVEN if there is a node_modules entry. The dependency may be a peer or dev dependency. Here I check for those.