### PR TITLE
Source code support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Backtrace Node Release Notes
 
+## Version 1.0.9 
+- Backtrace client allows to disable sourceCode integration. Backtrace-node initialization options allows you to pass sourceCode flag. If flag is equal to true, then your javascript code will be available in the report. If you set it to false, then report won't generate source code. By default this option is enabled.
+
+## Version 1.0.8
+- dependency updates
+
 ## Version 1.0.7
 - Full source map support,
 - readme updates

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Now, Backtrace-node supports sampling attribute. By using this argument, you can
 
 Backtrace-node supports client rate limiting! You can define how many reports per one minute you want to send to Backtrace by adding the additional option to the BacktraceClientOptions object. Now, when you reach the defined limit, the client will skip the current report. You can still learn which report won’t be available on the server by using event-emitter and ‘rate-limit’ events or by checking BacktraceResult – object that will return the reportSync/reportAsync method.
 
+#### `sourceCode` 
+
+If this option is enabled, then BacktraceReport will include your JavaScript source code with BacktraceReport for better debugging experience. Otherwise backtrace-node won't read your source code. By default this option is enabled.
+
 ### bt.getBacktraceClient()
 
 Returns a new `BacktraceClient` instance that you can use to send data to Backtrace. You can create new `BacktraceClient` manually and then replace existing default `BacktraceClient` with yours by using `use` method.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backtrace-node",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Backtrace error reporting tool",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/source/backtraceApi.ts
+++ b/source/backtraceApi.ts
@@ -9,12 +9,16 @@ import { BacktraceReport } from './model/backtraceReport';
 import { BacktraceResult } from './model/backtraceResult';
 
 export class BacktraceApi extends EventEmitter {
+  private _sourceCodeSupport = true;
+  public setSourceCodeSupport(enable: boolean) {
+    this._sourceCodeSupport = enable === true;
+  }
   constructor(private backtraceUri: string, private timeout: number) {
     super();
   }
 
   public async send(report: BacktraceReport): Promise<BacktraceResult> {
-    const data = await report.toJson();
+    const data = await report.toJson(this._sourceCodeSupport);
     this.emit('before-data-send', report, data);
     const formData = await this.getFormData(report, data);
     try {

--- a/source/backtraceClient.ts
+++ b/source/backtraceClient.ts
@@ -27,6 +27,7 @@ export class BacktraceClient extends EventEmitter {
       ...clientOptions,
     } as BacktraceClientOptions;
     this._backtraceApi = new BacktraceApi(this.getSubmitUrl(), this.options.timeout);
+    this._backtraceApi.setSourceCodeSupport(this.options.sourceCode);
     this._clientRateLimit = new ClientRateLimit(this.options.rateLimit);
     this.registerHandlers();
   }

--- a/source/model/backtraceClientOptions.ts
+++ b/source/model/backtraceClientOptions.ts
@@ -14,6 +14,7 @@ export class BacktraceClientOptions implements IBacktraceClientOptions {
   public sampling: number | undefined = undefined;
   public rateLimit: number = 0;
   public debugBacktrace: boolean = false;
+  public sourceCode: boolean = true;
 }
 
 export interface IBacktraceClientOptions {
@@ -28,4 +29,5 @@ export interface IBacktraceClientOptions {
   contextLineCount?: number;
   sampling?: number | undefined;
   rateLimit?: number;
+  sourceCode?: boolean;
 }

--- a/source/model/backtraceReport.ts
+++ b/source/model/backtraceReport.ts
@@ -185,7 +185,7 @@ export class BacktraceReport {
     return this.attachments;
   }
 
-  public async toJson(): Promise<IBacktraceData> {
+  public async toJson(includeSourceCode: boolean = true): Promise<IBacktraceData> {
     // why library should wait to retrieve source code data?
     // architecture decision require to pass additional parameters
     // not in constructor, but in additional method.
@@ -203,7 +203,7 @@ export class BacktraceReport {
       agentVersion: this.agentVersion,
       annotations: this.annotations,
       attributes: this.attributes,
-      sourceCode: this.stackTrace.getSourceCode(),
+      sourceCode: includeSourceCode ? this.stackTrace.getSourceCode() : undefined,
       symbolication_maps: this._symbolicationMap || this.stackTrace.symbolicationMaps,
     } as IBacktraceData;
 

--- a/test/reportTests.ts
+++ b/test/reportTests.ts
@@ -190,4 +190,18 @@ describe('Backrace report tests', () => {
       assert.isNotEmpty(report);
     });
   });
+
+  describe('Source code support', () => {
+    it('Should generate source code object by default', async () => {
+      const report = bt.BacktraceReport();
+      const data = await report.toJson();
+      assert.isDefined(data.sourceCode);
+    });
+
+    it(`Shouldn't generate source code when source code is disabled`, async () => {
+      const report = bt.BacktraceReport();
+      const data = await report.toJson(false);
+      assert.isUndefined(data.sourceCode);
+    });
+  });
 });


### PR DESCRIPTION
Backtrace client allows to disable sourceCode integration. Backtrace-node initialization options allows you to pass sourceCode flag. If flag is equal to true, then your javascript code will be available in the report. If you set it to false, then report won't generate source code. By default this option is enabled.