### PR TITLE
Improve logging message

### DIFF
--- a/source/const/application.ts
+++ b/source/const/application.ts
@@ -1,4 +1,4 @@
 export const APP_NAME = 'backtrace-node';
 export const VERSION = '1.2.0';
 export const LANG = 'nodejs';
-export const THREAD = 'main'; 
+export const THREAD = 'main';

--- a/source/helpers/moduleResolver.ts
+++ b/source/helpers/moduleResolver.ts
@@ -59,8 +59,7 @@ function readParentDir(root: string, depth: number) {
   return readModule(parent, --depth);
 }
 
-
-export function readSystemAttributes(): {[index: string]: any} {
+export function readSystemAttributes(): { [index: string]: any } {
   const mem = process.memoryUsage();
   const result = {
     'process.age': Math.floor(process.uptime()),

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -17,7 +17,9 @@ export class BacktraceMetrics {
   constructor(
     configuration: BacktraceClientOptions,
     private readonly attributeProvider: () => object,
-    private readonly _logger: { error(...data: any[]): void } | undefined,
+    private readonly _logger: { warn(...data: any[]): void, error(...data: any[]): void } | undefined,
+
+    private readonly eventsErrorWarning = 'Could not submit metrics. Are stability metrics enabled on your instance? Enable metrics ingenstion or disable this feature by providing `{ enableMetricsSupport: false}` in options.'
   ) {
     if (!configuration.endpoint) {
       throw new Error(`Backtrace: missing 'endpoint' option.`);
@@ -78,7 +80,8 @@ export class BacktraceMetrics {
     try {
       await post(this.uniqueEndpoint, payload);
     } catch (e) {
-      this._logger?.error(`Encountered error sending unique event: ${e?.message}`);
+      this._logger?.error(`Encountered error sending unique event: ${(e as Error).message}`);
+      this._logger?.warn(this.eventsErrorWarning)
     }
   }
 
@@ -106,7 +109,8 @@ export class BacktraceMetrics {
     try {
       await post(this.summedEndpoint, payload);
     } catch (e) {
-      this._logger?.error(`Encountered error sending summed event: ${e?.message}`);
+      this._logger?.error(`Encountered error sending summed event: ${(e as Error).message}`);
+      this._logger?.warn(this.eventsErrorWarning)
     }
   }
 

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -13,13 +13,13 @@ export class BacktraceMetrics {
   private uniqueEndpoint: string;
 
   private sessionId: string = uuid();
+  private readonly eventsErrorWarning =
+    'Could not submit metrics. Are stability metrics enabled on your instance? Enable metrics ingenstion or disable this feature by providing `{ enableMetricsSupport: false}` in options.';
 
   constructor(
     configuration: BacktraceClientOptions,
     private readonly attributeProvider: () => object,
-    private readonly _logger: { warn(...data: any[]): void, error(...data: any[]): void } | undefined,
-
-    private readonly eventsErrorWarning = 'Could not submit metrics. Are stability metrics enabled on your instance? Enable metrics ingenstion or disable this feature by providing `{ enableMetricsSupport: false}` in options.'
+    private readonly _logger: { warn(...data: any[]): void; error(...data: any[]): void } | undefined,
   ) {
     if (!configuration.endpoint) {
       throw new Error(`Backtrace: missing 'endpoint' option.`);
@@ -81,7 +81,7 @@ export class BacktraceMetrics {
       await post(this.uniqueEndpoint, payload);
     } catch (e) {
       this._logger?.error(`Encountered error sending unique event: ${(e as Error).message}`);
-      this._logger?.warn(this.eventsErrorWarning)
+      this._logger?.warn(this.eventsErrorWarning);
     }
   }
 
@@ -110,7 +110,7 @@ export class BacktraceMetrics {
       await post(this.summedEndpoint, payload);
     } catch (e) {
       this._logger?.error(`Encountered error sending summed event: ${(e as Error).message}`);
-      this._logger?.warn(this.eventsErrorWarning)
+      this._logger?.warn(this.eventsErrorWarning);
     }
   }
 

--- a/source/model/backtraceReport.ts
+++ b/source/model/backtraceReport.ts
@@ -43,7 +43,7 @@ export class BacktraceReport {
   // Backtrace-ndoe name
   public readonly agent = APP_NAME;
   // Backtrace-node  version
-  public readonly agentVersion= VERSION;
+  public readonly agentVersion = VERSION;
   // main thread name
   public readonly mainThread = THREAD;
 

--- a/source/utils/index.ts
+++ b/source/utils/index.ts
@@ -49,18 +49,14 @@ type EndpointParameters = {
 /**
  * Get universe and token from the endpoint.
  */
-export function getEndpointParams(
-  endpoint: string,
-  token?: string,
-): EndpointParameters | undefined {
+export function getEndpointParams(endpoint: string, token?: string): EndpointParameters | undefined {
   if (!endpoint) {
     return undefined;
   }
 
   if (endpoint.indexOf('submit.backtrace.io') !== -1) {
     const positionFilter = 'backtrace.io/';
-    const startPosition =
-      endpoint.indexOf('backtrace.io/') + positionFilter.length;
+    const startPosition = endpoint.indexOf('backtrace.io/') + positionFilter.length;
     if (startPosition === -1) {
       return undefined;
     }
@@ -68,20 +64,14 @@ export function getEndpointParams(
     if (indexOfTheEndOfTheUniverseName === -1) {
       return undefined;
     }
-    const universeName = endpoint.substring(
-      startPosition,
-      indexOfTheEndOfTheUniverseName,
-    );
+    const universeName = endpoint.substring(startPosition, indexOfTheEndOfTheUniverseName);
 
     if (!token) {
       const lastSeparatorIndex = endpoint.lastIndexOf('/');
       if (lastSeparatorIndex === indexOfTheEndOfTheUniverseName) {
         return undefined;
       }
-      token = endpoint.substring(
-        indexOfTheEndOfTheUniverseName + 1,
-        lastSeparatorIndex,
-      );
+      token = endpoint.substring(indexOfTheEndOfTheUniverseName + 1, lastSeparatorIndex);
       if (!token || token.length !== 64) {
         return undefined;
       }
@@ -110,23 +100,23 @@ export function getEndpointParams(
 export async function post(
   url: string,
   data: Record<string, unknown>,
-  options?: { timeout?: number, headers?: any },
+  options?: { timeout?: number; headers?: any },
 ): Promise<void> {
   const DEFAULT_TIMEOUT = 15000; // Fifteen seconds in ms
 
   try {
-      const defaultOptions = {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        timeout: DEFAULT_TIMEOUT,
-      }
+    const defaultOptions = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      timeout: DEFAULT_TIMEOUT,
+    };
 
-      const res = await axios.post(url, data, {...defaultOptions, ...options})
-      if (res.status !== 200) {
-        return Promise.reject(new Error(`Invalid attempt to submit error to Backtrace. Result: ${res}`));
-      }
-      return
+    const res = await axios.post(url, data, { ...defaultOptions, ...options });
+    if (res.status !== 200) {
+      return Promise.reject(new Error(`Invalid attempt to submit error to Backtrace. Result: ${res}`));
+    }
+    return;
   } catch (err) {
     return Promise.reject(err);
   }


### PR DESCRIPTION
Error messages were not helpful in informing the user why a metrics submission call would fail.
* Adding message to inform users to try enabling stability metrics or by disabling the feature to prevent the failed api calls.
* Improved formatting